### PR TITLE
Checking if bin folder exists first.

### DIFF
--- a/src/Service/InstallToBin.php
+++ b/src/Service/InstallToBin.php
@@ -58,6 +58,9 @@ final class InstallToBin extends AbstractService {
             $userBinDir = getenv('HOME') . '/bin';
             if (in_array($userBinDir, $dirs)) {
                 $binDir = $userBinDir;
+                if (!file_exists($binDir)) {
+                    throw new Exception('Your ~/bin directory does not exist. Please create it first before installing mchef there.');
+                }
             } else if (in_array('/usr/local/bin', $dirs)) {
                 $binDir = '/usr/local/bin';
             } else {


### PR DESCRIPTION
I got this error when installing. Fresh server and it didn't have a bin folder but it did have it in its path.

```
php mchef.php -i
ℹ Mchef: 1.0.0 © Citricity 2024 onwards. www.citricity.com
ℹ Installing to bin folder
ln: failed to create symbolic link '/home/homelab/bin/mchef': No such file or directory
☠ Exec failed : sudo ln -s '/home/homelab/work/freelance-dev/mchef/src/Service/../../bin/mchef.php' '/home/homelab/bin/mchef'
```

I added a small check to first validate that the folder exists.