### PR TITLE
fix(plugins): limit explode to first underscore in plugin name

### DIFF
--- a/src/Service/Plugins.php
+++ b/src/Service/Plugins.php
@@ -28,7 +28,7 @@ class Plugins extends AbstractService {
 
     private function getBaseMoodlePluginPath(string $pluginName): string {
         $path = '';
-        $parts = explode('_', $pluginName);
+        $parts = explode('_', $pluginName, 2);
         $type = array_shift($parts);
 
         switch ($type) {


### PR DESCRIPTION
Plugin names like tool_ai_bridge split into three parts, causing implode('/') to build wrong paths. Limit to 2 so the name component preserves its underscores intact.